### PR TITLE
setaria italica is a C4 plant

### DIFF
--- a/ICASA Data Dictionary - Crop_co.csv
+++ b/ICASA Data Dictionary - Crop_co.csv
@@ -56,7 +56,7 @@ FIG,Fig,Ficus carica,Fruit,,,FG,Fig,,C3,Perennial,,,Fruit,,N,Transplant,,Fruit c
 FLX,Flax,Linum usitatissimum,Fiber,,,FX,,,C3,Annual,,,Stem,,N,Seed,,Fiber,,,,,,,,,,,,,,,,,,,
 FML,Finger millet,Eleusine coracana,Cereal,,,,,,C4,Annual,,,Seed,,N,,,Cereals,,,,,,,,,,,,,,,,,,,
 FRG,Forage generic,(various),Forage,,Unidentified forage crop,G0,,,NA,Perennial,,,Shoot,,N,,,Forages,DSCSM046,PRFRM,FORAGE-Generic,,,,,,,,,,,,,,,,
-FXM,Foxtail millet,Setaria italica,Cereal,,,FM,Foxtailmillet,,C3,Annual,,,Seed,,N,Seed,,Cereals,,,,,,,,,,,,,,,,,,,
+FXM,Foxtail millet,Setaria italica,Cereal,,,FM,Foxtailmillet,,C4,Annual,,,Seed,,N,Seed,,Cereals,,,,,,,,,,,,,,,,https://en.wikipedia.org/wiki/Foxtail_millet,,,
 GRV,Grass vegetations,(various),NA,,,GR,Grassvegetations,,NA,NA,,,NA,,N,NA,,Various,,,,,,,,,,,,,,,,,,,
 GRW,Grass weeds,(various),NA,,,GW,Weed,,NA,NA,,,NA,,N,NA,,Various,,,,,,,,,,,,,,,,,,,
 GUA,Guayule,Parthenium argentatum,Latex,,,GY,Guayule,,C3,Perennial,,,Stem,,N,Transplant,Seed,Latex,,,,,,,,,,,,,,,,en.wikipedia.org/wiki/Parthenium_argentatum,,,


### PR DESCRIPTION
- may also need to be changed in other crop code files I wasn't sure if this is the right spot?

- S. italica (domesticated version of S. viridis) is a C4 plant. It is named in first paragraph of intro in Brutnell et al 2010:
![image](https://user-images.githubusercontent.com/464871/110874827-b09ed480-8291-11eb-8612-ec48a9c016c2.png)

_Brutnell, Thomas P., et al. "Setaria viridis: a model for C4 photosynthesis." The Plant Cell 22.8 (2010): 2537-2544. https://doi.org/10.1105/tpc.110.075309_
